### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,4 +1,6 @@
 name: clang-format Check
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   formatting-check:

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -1,4 +1,6 @@
 name: Check CMake Formatting
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/conventional-commit-check-pr.yml
+++ b/.github/workflows/conventional-commit-check-pr.yml
@@ -1,5 +1,7 @@
 name: Conventional commit check
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   cog_check_job:

--- a/.github/workflows/conventional-commit-check-push.yml
+++ b/.github/workflows/conventional-commit-check-push.yml
@@ -1,4 +1,6 @@
 name: Conventional commit check
+permissions:
+  contents: read
 on: [push]
 
 jobs:

--- a/.github/workflows/qt-build-release-linux.yml
+++ b/.github/workflows/qt-build-release-linux.yml
@@ -1,4 +1,6 @@
 name: CMake build release for linux
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/reademe-contributors.yml
+++ b/.github/workflows/reademe-contributors.yml
@@ -7,6 +7,8 @@ on:
       - main
 
 name: Generate a list of contributors
+permissions:
+  contents: write
 
 jobs:
   contrib-readme-en-job:


### PR DESCRIPTION
Potential fix for [https://github.com/Wing-summer/WingHexExplorer2/security/code-scanning/8](https://github.com/Wing-summer/WingHexExplorer2/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (updating the README files with contributor information), the `contents: write` permission is likely sufficient. This permission allows the workflow to update files in the repository without granting excessive access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`contrib-readme-en-job`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
