### PR TITLE
fix: 添加 CMAKE_INSTALL_RPATH=$ORIGIN 以修复共享库加载失败

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(WingHexExplorer2 LANGUAGES CXX)
 
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)


### PR DESCRIPTION
WingHexExplorer2 安装到 /opt/WingHexExplorer2/ 后，运行时报错找不到 libWingPlugin.so：

/opt/WingHexExplorer2/WingHexExplorer2: error while loading shared libraries: libWingPlugin.so: cannot open shared object file

虽然有 .desktop 启动文件，但直接从终端或命令行调用时仍然会触发该错误。将 CMAKE_INSTALL_RPATH 设为 $ORIGIN 让运行时从自身所在目录搜索共享库，或许是一个更彻底的解决方案。